### PR TITLE
boot: increase kernel and stack memory limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ dist/pearl.bin: mk/bin/kernel.bin mk/bin/bootsect.bin | dist
 	chmod +x dist/pearl.bin
 
 # Kernel size limits (in bytes)
-KERNEL_MAX_SIZE = 16896  # 33 sectors * 512 bytes
-KERNEL_WARN_SIZE = 15872  # Warn at ~31 sectors
+KERNEL_MAX_SIZE = 20992  # 41 sectors * 512 bytes
+KERNEL_WARN_SIZE = 19968  # Warn at 39 sectors
 
 mk/bin/kernel.bin: $(KERNEL_OBJECTS) $(DRIVER_OBJECT) $(CPU_OBJECTS) $(LIB_OBJECTS) $(FILESYSTEM_OBJECTS) | mk/bin
 	$(LINKER) -o $@ -Ttext 0x1000 $^ --oformat binary

--- a/boot/config.asm
+++ b/boot/config.asm
@@ -4,8 +4,8 @@
 ;
 ;     <https://firstdonoharm.dev/version/3/0/core.txt>
 
-KERNEL_SIZE   db  33
-STACK_OFFSET  db  9000
+KERNEL_SIZE   db  41
+STACK_OFFSET  equ  16384
 KERNEL_OFFSET equ 0x1000
 
 MSG_REAL_MODE    db "Started in 16-bit Real Mode",     0


### PR DESCRIPTION

-> Increased KERNEL_SIZE from 33 -> 41 sectors (16.5KB -> 20.5KB)
-> Increased stack size from 9KB -> 16KB
-> Updated Makefile size checks to match new limits